### PR TITLE
Фикс зависимости от six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
 
-    install_requires=['setuptools', 'requests'],
+    install_requires=['setuptools', 'requests', 'six'],
 
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
При установке под python2 требуется зависмость six.
Проверено под python 2.7.15